### PR TITLE
Add trimmed validator to check for leading or trailing spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ TextFormField(
 - [Pattern](#pattern)
 - [Must Match](#must-match)
 - [Compose](#compose)
+- [Trimmed](#trimmed)
 
 All validator functions have return type of `FormFieldValidator<String>` which is a required type for `validator` field in `TextFormField`.
 
@@ -288,9 +289,31 @@ This code will validate that _Name_ is non-empty and has a character length betw
 
 ---
 
+### Trimmed
+`Validators.required(String errorMessage)` is validator that requires the field's value to not have spaces at the beginning or end.
+
+#### Example
+This code will validate that the field does not have leading or trailing spaces
+```dart
+TextFormField(
+  decoration: InputDecoration(
+    labelText: 'Name',
+  ),
+  validator: Validators.trimmed('Spaces at the beginning or end not allowed'),
+),
+```
+#### Parameters
+
+| Params       | Description                                                                                  |
+| ------------ | -------------------------------------------------------------------------------------------- |
+| errorMessage | `String` value is passed to this parameter to show an error in case of a validation failure. |
+
+
+---
+
 #### **_Note:_**
 
->If `TextFormField`'s value is empty, then validators [Minimum](#minimum), [Maximum](#maximum), [Email](#email), [Minimum Length](#minimum-length), [Maximum Length](#maximum-length), [Must Match](#must-match) and [Pattern](#pattern) won't return any error because it considers `TextFormField` as optional. Use these validators in combination with the [Required](#required) validator if the specified `TextFormField` is compulsory and you want a validation failure if the field is empty. Check [Compose](#compose) validator to find out how to merge multiple validators.
+>If `TextFormField`'s value is empty, then validators [Minimum](#minimum), [Maximum](#maximum), [Email](#email), [Minimum Length](#minimum-length), [Maximum Length](#maximum-length), [Must Match](#must-match), [Pattern](#pattern) and [Trimmed](#trimmed) won't return any error because it considers `TextFormField` as optional. Use these validators in combination with the [Required](#required) validator if the specified `TextFormField` is compulsory and you want a validation failure if the field is empty. Check [Compose](#compose) validator to find out how to merge multiple validators.
 
 ___
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -8,6 +8,7 @@ import 'min_length_validation_container.dart';
 import 'max_length_validation_container.dart';
 import 'pattern_validation_container.dart';
 import 'compose_validation_container.dart';
+import 'trimmed_validation_container.dart';
 
 void main() => runApp(MyApp());
 
@@ -73,6 +74,8 @@ class _Body extends StatelessWidget {
         Divider(),
         SizedBox(height: 8),
         ComposeValidationContainer(),
+        SizedBox(height: 8),
+        TrimmedValidationContainer(),
       ],
     );
   }

--- a/example/lib/trimmed_validation_container.dart
+++ b/example/lib/trimmed_validation_container.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:wc_form_validators/wc_form_validators.dart';
+
+class TrimmedValidationContainer extends StatefulWidget {
+  @override
+  _TrimmedValidationContainerState createState() =>
+      _TrimmedValidationContainerState();
+}
+
+class _TrimmedValidationContainerState
+    extends State<TrimmedValidationContainer> {
+  final formKey = GlobalKey<FormState>();
+
+  @override
+  Widget build(BuildContext context) {
+    return Form(
+      key: formKey,
+      child: Column(
+        children: [
+          TextFormField(
+            decoration: InputDecoration(
+              labelText: 'Name',
+            ),
+            validator: Validators.trimmed(
+                'Spaces at the beginning or end not allowed'),
+          ),
+          ElevatedButton(
+            child: Text('Validate Trimmed field'),
+            onPressed: () {
+              formKey.currentState?.validate();
+            },
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/wc_form_validators.dart
+++ b/lib/wc_form_validators.dart
@@ -321,6 +321,36 @@ class Validators {
     };
   }
 
+  /// Validator that requires the field's value to not have spaces at the beginning or end
+  ///
+  ///
+  /// ### Validate that the field does not have leading or trailing spaces
+  ///
+  /// ```dart
+  ///           TextFormField(
+  ///            decoration: InputDecoration(
+  ///              labelText: 'Name',
+  ///            ),
+  ///            validator: Validators.trimmed('Spaces at the beginning or end not allowed'),
+  ///          ),
+  /// ```
+  ///
+  static FormFieldValidator<String> trimmed(String errorMessage) {
+    return (value) {
+      if (value == null) {
+        value = '';
+      }
+      if (value.isEmpty)
+        return null;
+      else {
+        if (value.trim() != value) {
+          return errorMessage;
+        }
+        return null;
+      }
+    };
+  }
+
   // -------------------- private functions ---------------------- //
 
   static double _toDouble(String value) {


### PR DESCRIPTION
This PR adds a new validator named trimmed to the Validators class.

```
TextFormField(
  decoration: InputDecoration(
    labelText: 'Name',
  ),
  validator: Validators.trimmed(
      'Spaces at the beginning or end not allowed'),
)
```